### PR TITLE
fix(release): pass npm auth token to semantic release

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -57,3 +57,4 @@ runs:
         extra_plugins: ${{ inputs.extra-plugins }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}


### PR DESCRIPTION

**Description**

This is needed to publish packages.

**Changes**

* fix(release): pass npm auth token to semantic release

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
