### PR TITLE
feat: allow configuring level for reviewdog

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -12,6 +12,10 @@ inputs:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
     default: ${{ github.token }}
+  level:
+    required: false
+    description: The output status behavior we want for the action
+    default: "error"
   npm-auth-token:
     required: false
     description: The Node Package Manager (npm) authentication token
@@ -34,6 +38,7 @@ runs:
       uses: reviewdog/action-eslint@v1
       with:
         github_token: ${{ inputs.github-token }}
+        level: ${{ inputs.level }}
         eslint_flags: ${{ inputs.eslint-flags }}
         reporter: github-check
     - name: Pre-commit


### PR DESCRIPTION
It seems reviewdog's level param is counterintuitive and it refers to the behavior we want for the action when there are annotations (i.e. when there are either errors, warnings or notices).

Since we currently don't pass a level param to reviewdog, it is picking the default, which is `error`: https://github.com/reviewdog/action-eslint/blob/master/action.yml#L12

From reviewdog's source code, it seems as soon as there are annotations (https://github.com/reviewdog/reviewdog/blob/master/doghouse/server/doghouse.go#L101) from the lint output, then when calling `conclusion` we can see that it will `failure` if the level is `error` and `neutral` for `info` and `warning`

This PR aims to test if by passing `warning` as `level` we can avoid failures of our actions for warnings, which are prominent in our `front-end` code. Example: https://github.com/turo/web-iframes-app/runs/7881298917?check_suite_focus=true