### PR TITLE
fix: add fail-on-error param (to combine w/ level)

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -23,7 +23,9 @@ jobs:
 | -------------- | -------------------------------------------------------------------------- | -------- | ------- |
 | checkout-repo  | Perform checkout as first step of action                                   | `false`  | true    |
 | eslint-flags   | Flags and args of eslint command                                           | `false`  |         |
+| fail-on-error  | Exit code for reviewdog when errors are found [true, false]                | `false`  | false   |
 | github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| level          | The output status behavior we want for the action [error, warning, info]   | `false`  | error   |
 | npm-auth-token | The Node Package Manager (npm) authentication token                        | `false`  |         |
 
 ## Runs

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -8,13 +8,21 @@ inputs:
   eslint-flags:
     required: false
     description: Flags and args of eslint command
+  fail-on-error:
+    required: false
+    description: |
+      Exit code for reviewdog when errors are found [true, false]
+      Default is `false`.
+    default: "false"
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
     default: ${{ github.token }}
   level:
     required: false
-    description: The output status behavior we want for the action
+    description: |
+      The output status behavior we want for the action [error, warning, info]
+      Default is `error`
     default: "error"
   npm-auth-token:
     required: false
@@ -39,6 +47,7 @@ runs:
       with:
         github_token: ${{ inputs.github-token }}
         level: ${{ inputs.level }}
+        fail_on_error: ${{ inputs.fail-on-error }}
         eslint_flags: ${{ inputs.eslint-flags }}
         reporter: github-check
     - name: Pre-commit


### PR DESCRIPTION
Hopefully having level as "warning" and adding fail-on-error to "true" makes this work as we expected (report all warnings and errors but only fail if it is an error)

Follow up of: https://github.com/open-turo/actions-node/pull/10