### PR TITLE
feat: try github-pr-review instead of github-check

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -49,6 +49,6 @@ runs:
         level: ${{ inputs.level }}
         fail_on_error: ${{ inputs.fail-on-error }}
         eslint_flags: ${{ inputs.eslint-flags }}
-        reporter: github-check
+        reporter: github-pr-review
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1


### PR DESCRIPTION
Have we considered trying this other reporter?

Seems nicer as it actually creates reviews and comments, and also seems to be the default currently.

Maybe there is a reason I'm missing for using the `github-check` instead, so creating this PR for discussion.

Link to the docs: https://github.com/reviewdog/reviewdog#reporter-github-pullrequest-review-comment--reportergithub-pr-review