### PR TITLE
feat: update semantic release action to v3

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -51,7 +51,7 @@ runs:
         NODE_ENV: production
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v3
       with:
         dry_run: ${{ inputs.dry-run }}
         extra_plugins: ${{ inputs.extra-plugins }}


### PR DESCRIPTION

**Description**

We could be more flexible and not make this a breaking change, but since we are moving to Node 16 (if we haven't already everywhere else) I think it's ok to just assume Node 16 is the minimum.

**Changes**

* feat: update semantic release action to v3

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
