### PR TITLE
fix: adds missing id so step outputs are forwarded

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -51,6 +51,7 @@ runs:
         NODE_ENV: production
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Release
+      id: release
       uses: cycjimmy/semantic-release-action@v3
       with:
         dry_run: ${{ inputs.dry-run }}


### PR DESCRIPTION

**Description**

I wasn't able to see the output in a consumer so I had a look and we're missing an id for proper forwarding.



**Changes**

* fix: adds missing id so step outputs are forwarded

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
