### PR TITLE
fix(release): don't persist credentials when checking out the repo

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -36,7 +36,8 @@ runs:
       uses: actions/checkout@v3
       if: inputs.checkout-repo
       with:
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.checkout-repo == 'true' && 0 || 1 }}
+        persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     - name: Install dependencies


### PR DESCRIPTION

**Description**

This changes originates from https://github.com/semantic-release/git/issues/196. Trying to get to use semantic-release/git in combination with this action. In order for this to work, we have to be able to get semantic release to use the passed `GITHUB_TOKEN` instead of the default git configured

**Changes**

* fix(release): don't persist credentials when checking out the repo

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
