### PR TITLE
fix(release): remove not needed if for force-depth

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -36,7 +36,7 @@ runs:
       uses: actions/checkout@v3
       if: inputs.checkout-repo
       with:
-        fetch-depth: ${{ inputs.checkout-repo == 'true' && 0 || 1 }}
+        fetch-depth: 0
         persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1


### PR DESCRIPTION

**Description**

The check is not needed, as when executed `checkout-repo` will always be true

**Changes**

* fix(release): remove not needed if for force-depth

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
