### PR TITLE
feat: use npm instead of yarn when there is no yarn.lock

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -37,9 +37,21 @@ runs:
         fetch-depth: 0
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
-    - name: Install dependencies
+    - name: Check for yarn.lock
+      id: check_yarn_lock
+      uses: andstor/file-existence-action@v2
+      with:
+        files: yarn.lock
+    - name: Install dependencies (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn --pure-lockfile
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Install dependencies (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm ci
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Eslint

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -40,14 +40,34 @@ runs:
         persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
-    - name: Install dependencies
+    - name: Check for yarn.lock
+      id: check_yarn_lock
+      uses: andstor/file-existence-action@v2
+      with:
+        files: yarn.lock
+    - name: Install dependencies (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn --pure-lockfile
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-    - name: Build
+    - name: Install dependencies (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm ci
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Build (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn build
+      env:
+        NODE_ENV: production
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Build (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm run build
       env:
         NODE_ENV: production
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -24,13 +24,32 @@ runs:
       if: inputs.checkout-repo
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
-    - name: Install dependencies
+    - name: Check for yarn.lock
+      id: check_yarn_lock
+      uses: andstor/file-existence-action@v2
+      with:
+        files: yarn.lock
+    - name: Install dependencies (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn --pure-lockfile
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-    - name: Run tests
+    - name: Install dependencies (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm ci
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Run tests (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn test ${{ inputs.test-flags }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Run tests (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm run test ${{ inputs.test-flags }}
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}


### PR DESCRIPTION

**Description**

Repositories in open-turo use npm instead of yarn by default. This PR adds support to use npm in all the actions when there is no `yarn.lock` file in the repo.

Not sure if there is a nicer way to distinguish between yarn and npm in the action

**Changes**

* feat: use npm instead of yarn when there is no yarn.lock

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
