### PR TITLE
feat: add support to specify npm-token

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -19,14 +19,15 @@ jobs:
 
 ## Inputs
 
-| parameter      | description                                                                | required | default |
-| -------------- | -------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo  | Perform checkout as first step of action                                   | `false`  | true    |
-| eslint-flags   | Flags and args of eslint command                                           | `false`  |         |
-| fail-on-error  | Exit code for reviewdog when errors are found [true, false]                | `false`  | false   |
-| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| level          | The output status behavior we want for the action [error, warning, info]   | `false`  | error   |
-| npm-auth-token | The Node Package Manager (npm) authentication token                        | `false`  |         |
+| parameter      | description                                                                                                                                          | required | default |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| checkout-repo  | Perform checkout as first step of action                                                                                                             | `false`  | true    |
+| eslint-flags   | Flags and args of eslint command                                                                                                                     | `false`  |         |
+| fail-on-error  | Exit code for reviewdog when errors are found [true, false]                                                                                          | `false`  | false   |
+| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`   |         |
+| level          | The output status behavior we want for the action [error, warning, info]                                                                             | `false`  | error   |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`  |         |
+| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`  |         |
 
 ## Runs
 

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -26,7 +26,10 @@ inputs:
     default: "error"
   npm-auth-token:
     required: false
-    description: The Node Package Manager (npm) authentication token
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
 runs:
   using: composite
   steps:

--- a/release/README.md
+++ b/release/README.md
@@ -30,13 +30,14 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 
 ## Inputs
 
-| parameter      | description                                                                                                           | required | default |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo  | Perform checkout as first step of action                                                                              | `false`  | true    |
-| dry-run        | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false`  | `false` |
-| extra-plugins  | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
-| github-token   | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| npm-auth-token | The Node Package Manager (npm) authentication token                                                                   | `false`  |         |
+| parameter      | description                                                                                                                                          | required | default |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| checkout-repo  | Perform checkout as first step of action                                                                                                             | `false`  | true    |
+| dry-run        | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                | `false`  | `false` |
+| extra-plugins  | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.                                    | `false`  |         |
+| github-token   | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                | `true`   |         |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`  |         |
+| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`  |         |
 
 ## Outputs
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -11,7 +11,10 @@ inputs:
     default: ${{ github.token }}
   npm-auth-token:
     required: false
-    description: The Node Package Manager (npm) authentication token
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
   dry-run:
     required: false
     description: Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
@@ -51,12 +54,14 @@ runs:
       run: yarn --pure-lockfile
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Install dependencies (npm)
       if: steps.check_yarn_lock.outputs.files_exists == 'false'
       shell: bash
       run: npm ci
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Build (yarn)
       if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
@@ -64,6 +69,7 @@ runs:
       env:
         NODE_ENV: production
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Build (npm)
       if: steps.check_yarn_lock.outputs.files_exists == 'false'
       shell: bash
@@ -71,6 +77,7 @@ runs:
       env:
         NODE_ENV: production
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Release
       id: release
       uses: cycjimmy/semantic-release-action@v3
@@ -80,3 +87,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}

--- a/test/README.md
+++ b/test/README.md
@@ -19,12 +19,13 @@ jobs:
 
 ## Inputs
 
-| parameter      | description                                                                | required | default |
-| -------------- | -------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo  | Perform checkout as first step of action                                   | `false`  | true    |
-| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| npm-auth-token | The Node Package Manager (npm) authentication token                        | `false`  |         |
-| test-flags     | Flags and args for test command                                            | `false`  | ''      |
+| parameter      | description                                                                                                                                          | required | default |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| checkout-repo  | Perform checkout as first step of action                                                                                                             | `false`  | true    |
+| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`   |         |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`  |         |
+| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`  |         |
+| test-flags     | Flags and args for test command                                                                                                                      | `false`  | ''      |
 
 ## Runs
 

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -11,7 +11,10 @@ inputs:
     default: ${{ github.token }}
   npm-auth-token:
     required: false
-    description: The Node Package Manager (npm) authentication token
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
   test-flags:
     required: false
     description: Flags and args for test command
@@ -35,21 +38,25 @@ runs:
       run: yarn --pure-lockfile
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Install dependencies (npm)
       if: steps.check_yarn_lock.outputs.files_exists == 'false'
       shell: bash
       run: npm ci
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Run tests (yarn)
       if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
       run: yarn test ${{ inputs.test-flags }}
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Run tests (npm)
       if: steps.check_yarn_lock.outputs.files_exists == 'false'
       shell: bash
       run: npm run test ${{ inputs.test-flags }}
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION

**Description**

NPM by default uses the `NPM_TOKEN` env var to authenticate against npmjs.org. This PR adds support to specify this token in all the actions via the `npm-token` input.

It also keeps the `npm-auth-token` (updating the docs a bit), so we can still authenticate to at least one private registry by configuring a npmrc file.

**Changes**

* feat: add support to specify npm-token

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
