### PR TITLE
feat: add step to check for beta releases

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -19,15 +19,16 @@ jobs:
 
 ## Inputs
 
-| parameter      | description                                                                                                                                          | required | default |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo  | Perform checkout as first step of action                                                                                                             | `false`  | true    |
-| eslint-flags   | Flags and args of eslint command                                                                                                                     | `false`  |         |
-| fail-on-error  | Exit code for reviewdog when errors are found [true, false]                                                                                          | `false`  | false   |
-| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`   |         |
-| level          | The output status behavior we want for the action [error, warning, info]                                                                             | `false`  | error   |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`  |         |
-| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`  |         |
+| parameter                    | description                                                                                                                                          | required         | default |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
+| checkout-repo                | Perform checkout as first step of action                                                                                                             | `false`          | true    |
+| eslint-flags                 | Flags and args of eslint command                                                                                                                     | `false`          |         |
+| fail-on-error                | Exit code for reviewdog when errors are found [true, false]                                                                                          | `false`          | false   |
+| github-token                 | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`           |         |
+| level                        | The output status behavior we want for the action [error, warning, info]                                                                             | `false`          | error   |
+| npm-auth-token               | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`          |         |
+| npm-token                    | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`          |         |
+| internal-dependency-prefixes | Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values.                                            | `@turo,@example` |         |
 
 ## Runs
 
@@ -39,6 +40,7 @@ This action runs the following lint checks:
 
 - [action-pre-commit](https://github.com/open-turo/action-pre-commit)
 - eslint via [reviewdog](https://github.com/reviewdog/action-eslint)
+- beta release check - checks for beta versions of internal dependencies
 
 ## Notes
 

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -67,3 +67,5 @@ runs:
         reporter: github-pr-review
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1
+    - name: Beta Release Check
+      run: bash ./lint/scripts/beta-check.sh

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -30,6 +30,10 @@ inputs:
   npm-token:
     required: false
     description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+  internal-dependency-prefixes:
+    required: false
+    description: Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values e.g. '@turo,@example'.
+    default: ""
 runs:
   using: composite
   steps:
@@ -67,5 +71,7 @@ runs:
         reporter: github-pr-review
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1
-    - name: Beta Release Check
-      run: bash ./lint/scripts/beta-check.sh
+    - if: ${{ inputs.internal-dependency-prefixes != '' }}
+      name: Beta Release Check
+      run: ./lint/scripts/beta-check.sh ${{ inputs.internal-dependency-prefixes }}
+      shell: bash

--- a/lint/scripts/beta-check.sh
+++ b/lint/scripts/beta-check.sh
@@ -1,0 +1,6 @@
+set -e
+
+if egrep "@turo\/.*\-beta\-" package.json; then
+    echo "ERROR: should not consume a beta version of an internal dependency. Make sure to revert/update to use a proper release."
+    exit 1
+fi

--- a/lint/scripts/beta-check.sh
+++ b/lint/scripts/beta-check.sh
@@ -1,6 +1,7 @@
 set -e
 
-if egrep "$1.*\-beta\-" package.json; then
+delimited_prefixes=$(sed 's/ *, */|/g' <<< $1)
+if egrep "($delimited_prefixes).*\-beta\-" package.json; then
     echo "ERROR: should not consume a beta version of an internal dependency. Make sure to revert/update to use a proper release."
     exit 1
 fi

--- a/lint/scripts/beta-check.sh
+++ b/lint/scripts/beta-check.sh
@@ -1,6 +1,6 @@
 set -e
 
-if egrep "@turo\/.*\-beta\-" package.json; then
+if egrep "$1.*\-beta\-" package.json; then
     echo "ERROR: should not consume a beta version of an internal dependency. Make sure to revert/update to use a proper release."
     exit 1
 fi


### PR DESCRIPTION

**Description**

It would be good practice to warn/alert developers working in consumer packages that they are consuming a beta-release of a certain package, because ideally we wouldon’t really want to merge such a change, and would need to publish and consume a proper release first.

**Changes**

* feat: add step to check for beta releases

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
