### PR TITLE
CP-954: Run custom lint script instead of just eslint

### DIFF
--- a/docs/breaking-changes/v4.md
+++ b/docs/breaking-changes/v4.md
@@ -1,0 +1,11 @@
+# Upgrade from v3 to v4
+
+- `actions-node/lint`: This update changes the action's behavior from just running `eslint` to running an npm script passed by the consumer that would run all the lint checks they need.
+
+## Description of changes
+
+- `actions-node/lint`: The action now takes an input `lint-script`, which is the name of the npm script it is going to run as the primary lint check. The default value of the input is `lint`, meaning the action will run `yarn lint` or `npm run lint` depending on the package manager the consumer is using (which is picked up automatically).
+
+## Upgrade instructions
+
+- `actions-node/lint`: If the npm script to lint your code locally is anything other than `lint`, pass it to the `lint-script` input.

--- a/lint/README.md
+++ b/lint/README.md
@@ -11,7 +11,7 @@ jobs:
   build:
     steps:
       - name: Lint
-        uses: open-turo/actions-node/lint@v3
+        uses: open-turo/actions-node/lint@v4
         with:
           ## example value for github-token provided below
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,8 +21,8 @@ jobs:
 
 | parameter                    | description                                                                                                                                          | required         | default |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
-| checkout-repo                | Perform checkout as first step of action                                                                                                             | `false`          | true    |
-| eslint-flags                 | Flags and args of eslint command                                                                                                                     | `false`          |         |
+| checkout-repo                | Perform checkout as first step of action                                                                                                             | `false`          |         |
+| lint-script                  | Custom script to run, should be defined in consumer's package.json                                                                                   | `false`          | `lint`  |
 | github-token                 | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`           |         |
 | npm-auth-token               | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`          |         |
 | npm-token                    | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`          |         |

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -7,7 +7,7 @@ inputs:
     default: "true"
   lint-script:
     required: false
-    description: Custom script defined in package.json to run.
+    description: Custom script to run, should be defined in package.json.
     default: "lint"
   github-token:
     required: true

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -5,9 +5,10 @@ inputs:
     required: false
     description: Perform checkout as first step of action
     default: "true"
-  eslint-flags:
+  lint-script:
     required: false
-    description: Flags and args of eslint command
+    description: Custom script defined in package.json to run.
+    default: "lint"
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
@@ -49,9 +50,20 @@ runs:
       run: npm ci
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-    - name: Run eslint
+    - name: Run lint script (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
       shell: bash
-      run: npx eslint ${{ inputs.eslint-flags }}
+      run: npm run ${{ inputs.lint-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run lint script (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
+      shell: bash
+      run: yarn ${{ inputs.lint-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1
     - if: ${{ inputs.internal-dependency-prefixes != '' }}


### PR DESCRIPTION

**Description**

This allows the user to pass a custom script that they would have defined in package.json, that would run in CI, instead of only running eslint. This gives the user flexibility to run any other lint checks they might want, like type-checking etc.

Fixes [#CP-954](https://team-turo.atlassian.net//browse/CP-954)

**Changes**

* feat: run custom lint script instead of just eslint

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
