### PR TITLE
fix(lint): run pre-commit step if .pre-commit-config exists

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -64,11 +64,11 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
-    - name: Check for .pre-commit-config.yaml file
+    - name: Check for .pre-commit-config file
       id: check_pre_commit_config
       uses: andstor/file-existence-action@v2
       with:
-        files: .pre-commit-config.yaml
+        files: ".pre-commit-config.yaml, .pre-commit-config.yml"
     - name: Pre-commit
       if: steps.check_pre_commit_config.outputs.files_exists == 'true'
       uses: open-turo/action-pre-commit@v1

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -64,7 +64,13 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Check for .pre-commit-config.yaml file
+      id: check_pre_commit_config
+      uses: andstor/file-existence-action@v2
+      with:
+        files: .pre-commit-config.yaml
     - name: Pre-commit
+      if: steps.check_pre_commit_config.outputs.files_exists == 'true'
       uses: open-turo/action-pre-commit@v1
     - if: ${{ inputs.internal-dependency-prefixes != '' }}
       name: Create Beta Release Check Script


### PR DESCRIPTION
Running pre-commit is a definitely good practice, but not using pre-commit (if a consumer uses husky + lint-staged for example) shouldn't be a blocker to using this action