### PR TITLE
feat(release): use open-turo/actions-release/semantic-release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -17,6 +17,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/test@v1
+      - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,18 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
+  push:
 
 jobs:
+  release-notes:
+    name: Release notes preview
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: open-turo/actions-release/release-notes-preview@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/lint@v1
+      - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -17,7 +17,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/test@v1
+      - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -28,6 +28,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-gha/release@v1
+      - uses: open-turo/actions-gha/release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -23,17 +23,17 @@ inputs:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
     default: |
-      @open-turo/semantic-release-config@^1.4.0
+      @open-turo/semantic-release-config@v3
 outputs:
   new-release-published:
     description: Whether a new release was published
-    value: ${{ steps.release.outputs.new_release_published }}
+    value: ${{ steps.release.outputs.new-release-published }}
   new-release-version:
     description: Version of the new release
-    value: ${{ steps.release.outputs.new_release_version }}
+    value: ${{ steps.release.outputs.new-release-version }}
   new-release-major-version:
     description: Major version of the new release
-    value: ${{ steps.release.outputs.new_release_major_version }}
+    value: ${{ steps.release.outputs.new-release-major-version }}
 runs:
   using: composite
   steps:
@@ -82,11 +82,11 @@ runs:
         NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Release
       id: release
-      uses: cycjimmy/semantic-release-action@v3
+      uses: open-turo/actions-release/semantic-release@v2
       with:
-        dry_run: ${{ inputs.dry-run }}
-        extra_plugins: ${{ inputs.extra-plugins }}
+        dry-run: ${{ inputs.dry-run }}
+        extra-plugins: ${{ inputs.extra-plugins }}
+        github-token: ${{ inputs.github-token }}
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
instead of cycjimmy/semantic-release-action in order to support higher versions of semantic-release and node