### PR TITLE
feat: run lint release notes as part of lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,10 @@ repos:
     rev: v1.6.26
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/lint/README.md
+++ b/lint/README.md
@@ -17,21 +17,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Inputs
-
-| parameter                    | description                                                                                                                                          | required         | default |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------- |
-| checkout-repo                | Perform checkout as first step of action                                                                                                             | `false`          |         |
-| lint-script                  | Custom script to run, should be defined in consumer's package.json                                                                                   | `false`          | `lint`  |
-| github-token                 | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`           |         |
-| npm-auth-token               | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`          |         |
-| npm-token                    | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`          |         |
-| internal-dependency-prefixes | Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values.                                            | `@turo,@example` |         |
-
-## Runs
-
-This action is an `composite` action.
-
 ## Lint Checks
 
 This action runs the following lint checks:
@@ -39,8 +24,20 @@ This action runs the following lint checks:
 - [action-pre-commit](https://github.com/open-turo/action-pre-commit)
 - eslint via npx
 - beta release check - checks for beta versions of internal dependencies
+- [lint-release-notes](https://github.com/open-turo/actions-release/tree/main/lint-release-notes)
 
 ## Notes
 
 - By default, this action will perform actions/checkout as its first step.
 - This expects that `.commitlintrc.yaml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-runs -->
+<!-- action-docs-runs -->
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/README.md
+++ b/lint/README.md
@@ -33,10 +33,24 @@ This action runs the following lint checks:
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| lint-script | Custom script to run, should be defined in package.json. | `false` | lint |
+| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| internal-dependency-prefixes | Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values e.g. '@turo,@example'. | `false` |  |
 <!-- action-docs-inputs -->
 <!-- action-docs-outputs -->
+
 <!-- action-docs-outputs -->
 <!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
 <!-- action-docs-runs -->
 <!-- action-docs-usage  -->
 <!-- action-docs-usage -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -89,3 +89,6 @@ runs:
       name: Run Beta Release Check
       run: bash ${{ runner.temp }}/beta-check.sh ${{ inputs.internal-dependency-prefixes }}
       shell: bash
+    - name: Check release notes on pull_request
+      if: github.event_name == 'pull_request'
+      uses: open-turo/actions-release/lint-release-notes@v4

--- a/release/README.md
+++ b/release/README.md
@@ -28,28 +28,16 @@ steps:
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v3` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
-## Inputs
-
-| parameter      | description                                                                                                                                                               | required | default                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
-| checkout-repo  | Perform checkout as first step of action                                                                                                                                  | `false`  | true                                      |
-| dry-run        | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                                     | `false`  | `false`                                   |
-| extra-plugins  | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
-| github-token   | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.                      | `false`  |                                           |
-| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                                         | `false`  |                                           |
-
-## Outputs
-
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
-
-## Runs
-
-This action is an `composite` action.
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-runs -->
+<!-- action-docs-runs -->
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Additional Examples
 

--- a/release/README.md
+++ b/release/README.md
@@ -30,10 +30,30 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
 <!-- action-docs-inputs -->
 <!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
 <!-- action-docs-outputs -->
 <!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
 <!-- action-docs-runs -->
 <!-- action-docs-usage  -->
 <!-- action-docs-usage -->

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"/action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+done

--- a/test/README.md
+++ b/test/README.md
@@ -17,29 +17,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Inputs
-
-| parameter      | description                                                                                                                                          | required | default |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo  | Perform checkout as first step of action                                                                                                             | `false`  | true    |
-| github-token   | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                                                           | `true`   |         |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false`  |         |
-| npm-token      | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                    | `false`  |         |
-| test-flags     | Flags and args for test command                                                                                                                      | `false`  | ''      |
-
-## Runs
-
-This action is an `composite` action.
-
-## Test
-
-It will run:
-
-```shell
-yarn --pure-lockfile
-yarn test
-```
-
 ## Notes
 
 - By default, this action will perform actions/checkout as its first step.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-outputs -->
+<!-- action-docs-runs -->
+<!-- action-docs-runs -->
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/test/README.md
+++ b/test/README.md
@@ -23,10 +23,23 @@ jobs:
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| test-flags | Flags and args for test command | `false` |  |
 <!-- action-docs-inputs -->
 <!-- action-docs-outputs -->
+
 <!-- action-docs-outputs -->
 <!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
 <!-- action-docs-runs -->
 <!-- action-docs-usage  -->
 <!-- action-docs-usage -->


### PR DESCRIPTION

**Description**

Run open-turo/actions-release/lint-release notes if the event is a pull_request

Also add action-docs pre-commit hook to generate documentation

**Changes**

* feat: run lint release notes as part of lint
* build: use action-docs to generate readmes
* docs: update actions readme

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
