### PR TITLE
Add support for pre-release

### DIFF
--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -1,0 +1,85 @@
+# GitHub Action Build Docker
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
+## Description
+
+Builds and push docker images for the input platform, tags and image version
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
+
+## Usage
+
+This action will build and publish a docker image with appropriate tags.
+
+It assumes that the repo has a configuration file in `<repo-root>/.docker-config.json` with the following properties:
+
+- `imageName`: the image name (org/image-name)
+- `dockerfile`: the path to the dockerfile to build - defaults to `./Dockerfile`
+
+Example:
+
+```json
+{
+  "imageName": "turo/hello-world-msvc",
+  "dockerfile": "./Dockerfile"
+}
+```
+
+#### Basic Usage:
+
+```yaml
+steps:
+  - uses: open-turo/actions-node/release@v4
+    name: Release
+    id: release
+    with:
+      checkout-repo: true
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      dry-run: false
+  - uses: open-turo/actions-jvm/build-docker@v1
+    id: docker-build
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-version: ${{ steps.release.outputs.new-release-version }}
+      docker-metadata-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
+```
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
+| dockerhub-user | username for dockerhub | `true` |  |
+| dockerhub-password | password for dockerhub | `true` |  |
+| github-token | Usually secrets.GITHUB_TOKEN | `true` |  |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret | `false` |  |
+| image-version | Docker image version | `true` |  |
+| image-platform | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc) | `false` | linux/amd64 |
+| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input | `false` |  |
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| --- | --- |
+| image-name | Docker image name |
+| image-with-tag | Full image with tag - <image-name>:<image-version> |
+<!-- action-docs-outputs -->
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/build-docker/action.yaml
+++ b/build-docker/action.yaml
@@ -1,0 +1,105 @@
+name: Build & push docker images
+description: Builds and push docker images for the input platform, tags and image version
+inputs:
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.
+    default: .docker-config.json
+  docker-flavor:
+    required: false
+    description: Docker flavor to use for docker metadata
+    default: |
+      latest=false
+  dockerhub-user:
+    required: true
+    description: username for dockerhub
+  dockerhub-password:
+    required: true
+    description: password for dockerhub
+  github-token:
+    required: true
+    description: Usually secrets.GITHUB_TOKEN
+  npm-auth-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret
+  image-version:
+    required: true
+    description: Docker image version
+  image-platform:
+    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    required: false
+    default: linux/amd64
+  docker-metadata-tags:
+    description: "'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input"
+    required: false
+outputs:
+  image-name:
+    description: Docker image name
+    value: ${{ steps.config.outputs.image-name }}
+  image-with-tag:
+    description: Full image with tag - <image-name>:<image-version>
+    value: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dump GitHub context
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - id: config
+      shell: bash
+      run: |
+        # if docker-config file does not exist - fail
+        if [ ! -f "${{ inputs.docker-config-file }}" ]; then
+          echo "::error::Docker config file not found: ${{ inputs.docker-config-file }}" && exit 1
+        fi
+        image_name=$(jq -r .imageName ${{ inputs.docker-config-file }})
+        echo "image-name: ${image_name}"
+        echo "image-name=${image_name}" >> $GITHUB_OUTPUT
+        dockerfile=$(jq -r '.dockerfile // "./Dockerfile"' ${{ inputs.docker-config-file }})
+        echo "Dockerfile: ${dockerfile}"
+        echo "dockerfile=${dockerfile}" >> $GITHUB_OUTPUT
+        echo "image-version: ${{ inputs.image-version }}"
+        echo "image-platform: ${{ inputs.image-platform }}"
+        echo "docker-metadata-tags: ${{ inputs.docker-metadata-tags }}"
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-user }}
+        password: ${{ inputs.dockerhub-password }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ steps.config.outputs.image-name }}
+        flavor: ${{ inputs.docker-flavor }}
+        tags: |
+          ${{ inputs.image-tags }}
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: ${{ inputs.image-platform }}
+        file: ${{ steps.config.outputs.dockerfile }}
+        build-args: |
+          GIT_COMMIT=${{ github.sha }}
+          BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          VERSION=${{ inputs.image-version }}
+          REVISION=${{ inputs.image-version }}
+          BRANCH=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.branch'] }}
+        secrets: |
+          NPM_AUTH_TOKEN=${{ inputs.npm-auth-token }}
+          NPM_TOKEN=${{ inputs.npm-token }}
+        push: true
+        tags: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,56 @@
+# GitHub Action Lint
+
+## Description
+
+GitHub Action that lints a Node based repository
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    steps:
+      - name: Lint
+        uses: open-turo/actions-node/lint@v4
+        with:
+          ## example value for github-token provided below
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Lint Checks
+
+This action runs the following lint checks:
+
+- [action-pre-commit](https://github.com/open-turo/action-pre-commit)
+- eslint via npx
+- beta release check - checks for beta versions of internal dependencies
+- [lint-release-notes](https://github.com/open-turo/actions-release/tree/main/lint-release-notes)
+
+## Notes
+
+- By default, this action will perform actions/checkout as its first step.
+- This expects that `.commitlintrc.yaml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| build-script | Custom script to run, should be defined in package.json. | `false` | build |
+| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+<!-- action-docs-inputs -->
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/build/README.md
+++ b/build/README.md
@@ -1,8 +1,12 @@
-# GitHub Action Lint
+# GitHub Action Build
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
-GitHub Action that lints a Node based repository
+GitHub Action that builds Node based repository
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -1,0 +1,63 @@
+name: Build
+description: GitHub Action that builds Node based repository
+inputs:
+  checkout-repo:
+    required: false
+    description: Perform checkout as first step of action
+    default: "true"
+  build-script:
+    required: false
+    description: Custom script to run, should be defined in package.json.
+    default: "build"
+  github-token:
+    required: true
+    description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
+    default: ${{ github.token }}
+  npm-auth-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: inputs.checkout-repo == 'true'
+      with:
+        fetch-depth: 0
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v1
+    - name: Check for yarn.lock
+      id: check_yarn_lock
+      uses: andstor/file-existence-action@v2
+      with:
+        files: yarn.lock
+    - name: Install dependencies (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
+      shell: bash
+      run: yarn --pure-lockfile
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Install dependencies (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm ci
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Run build script (npm)
+      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      shell: bash
+      run: npm run ${{ inputs.build-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run lint script (yarn)
+      if: steps.check_yarn_lock.outputs.files_exists == 'true'
+      shell: bash
+      run: yarn ${{ inputs.build-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Lint
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that lints a Node based repository
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -1,0 +1,75 @@
+# GitHub Action: Prerelease
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
+## Description
+
+< GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release. Meant to only be run in the context of a pull request. This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR and docker credentials are present
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
+
+## Configuration
+
+### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) in your repository.
+
+### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in your repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) Environment Variables.
+
+### Step3: Add a [Workflow File](https://help.github.com/en/articles/workflow-syntax-for-github-actions) to your repository to create custom automated processes.
+
+## Usage
+
+```yaml
+steps:
+  - name: Action semantic release
+    uses: open-turo/actions-node/prerelease@v5
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN`
+with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part
+of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the
+required permission to operate on protected branches.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| create-prerelease | Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating | `false` | false |
+| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| dockerhub-user | username for dockerhub | `false` |  |
+| dockerhub-password | password for dockerhub | `false` |  |
+| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
+| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+| image-name | Docker image name |
+| image-with-tag | Full image with tag - <image-name>:<image-version> |
+| pull-request-number | Pull request number |
+| run-url | URL to the GHA run |
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -1,0 +1,239 @@
+name: GitHub Action Prelease
+description: <
+  GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the
+  latest release. Meant to only be run in the context of a pull request.
+  This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR
+  and docker credentials are present
+inputs:
+  checkout-repo:
+    required: false
+    description: Perform checkout as first step of action
+    default: "true"
+  create-prerelease:
+    required: false
+    description: Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating
+    default: "false"
+  github-token:
+    required: true
+    description: GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
+    default: ${{ github.token }}
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.
+    default: .docker-config.json
+  dockerhub-user:
+    required: false
+    description: username for dockerhub
+  dockerhub-password:
+    required: false
+    description: password for dockerhub
+  npm-auth-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+  npm-token:
+    required: false
+    description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+  extra-plugins:
+    required: false
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config
+outputs:
+  new-release-published:
+    description: Whether a new release was published
+    value: ${{ steps.prerelease.outputs.new-release-published }}
+  new-release-version:
+    description: Version of the new release
+    value: ${{ steps.prerelease.outputs.new-release-version }}
+  new-release-major-version:
+    description: Major version of the new release
+    value: ${{ steps.prerelease.outputs.new-release-major_version }}
+  image-name:
+    description: Docker image name
+    value: ${{ steps.build-docker.outputs.image-name }}
+  image-with-tag:
+    description: Full image with tag - <image-name>:<image-version>
+    value: ${{ steps.build-docker.outputs.image-with-tag }}
+  pull-request-number:
+    description: Pull request number
+    value: ${{ steps.PR.outputs.number }}
+  run-url:
+    description: URL to the GHA run
+    value: ${{ steps.vars.outputs.run-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      shell: bash
+      run: |
+        echo "::group::Github Context"
+        echo "$GITHUB_CONTEXT"
+        echo "::endgroup::"
+
+    - name: Set vars
+      id: source-vars
+      shell: bash
+      env:
+        event_name: ${{ github.event_name }}
+        dispatch_client_payload_ref: ${{ github.event.client_payload.ref }}
+        dispatch_client_payload_sha: ${{ github.event.client_payload.sha }}
+        push_ref_name: ${{ github.ref_name }}
+        push_sha: ${{ github.sha }}
+        pull_request_ref_name: ${{ github.event.pull_request.head.ref }}
+        pull_request_sha: ${{ github.event.pull_request.head.sha }}
+      run: |
+        echo "event_name=$event_name"
+
+        if [ "$event_name" == "push" ]; then
+          branch=$push_ref_name
+          sha=$push_sha
+        elif [ "$event_name" == "repository_dispatch" ]; then
+          branch=$dispatch_client_payload_ref
+          sha=$dispatch_client_payload_sha
+        elif [ "$event_name" == "pull_request" ]; then
+          branch=$pull_request_ref_name
+          sha=$pull_request_sha
+        else
+          echo "::error::Unsupported event type '$event_name'"
+          exit 1
+        fi
+
+        echo "branch=$branch"
+        echo "branch=$branch" >> $GITHUB_OUTPUT
+
+        echo "sha=$sha"
+        echo "sha=$sha" >> $GITHUB_OUTPUT
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ steps.source-vars.outputs.branch }}
+
+    # Find PR
+    - uses: 8BitJonny/gh-get-current-pr@2.2.0
+      id: PR
+      with:
+        sha: ${{ steps.source-vars.outputs.sha }}
+
+    - id: check-pr
+      shell: bash
+      run: |
+        if [ -z "${{ steps.PR.outputs.number }}" ]; then
+          echo "pr_found=false" >> $GITHUB_OUTPUT
+          echo "has_prerelease_label=false" >> $GITHUB_OUTPUT
+        else
+          echo "pr_found=true" >> $GITHUB_OUTPUT
+          echo "has_prerelease_label=${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}" >> $GITHUB_OUTPUT
+        fi
+        git branch
+        echo "branch: ${{ steps.source-vars.outputs.branch }}"
+
+    - if: steps.check-pr.outputs.pr_found != 'true'
+      shell: bash
+      run: echo "PR does not exist for branch (${{ steps.source-vars.outputs.branch }}) - ignoring"
+
+    - if: steps.check-pr.outputs.has_prerelease_label == 'true'
+      shell: bash
+      run: |
+        echo "Your PR number is ${{ steps.PR.outputs.number }}"
+        echo "::debug::labels.contains('prerelease'): ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}"
+
+    # Compute next release
+    - uses: open-turo/action-setup-tools@v1
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
+
+    - name: Build
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
+      uses: open-turo/actions-node/build@v5
+      with:
+        checkout-repo: false
+
+    - name: Prerelease
+      id: prerelease
+      uses: open-turo/actions-release/semantic-release@v4
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
+      with:
+        branches: '["main", {"name": "${{ steps.source-vars.outputs.branch }}","channel": "next","prerelease": "pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}"}]'
+        dry-run: ${{ inputs.create-prerelease == 'false' }}
+        extra-plugins: ${{ inputs.extra-plugins }}
+        github-token: ${{ inputs.github-token }}
+        override-github-ref-name: ${{ steps.source-vars.outputs.branch }}
+        override-github-sha: ${{ steps.source-vars.outputs.sha }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+    - id: vars
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
+      shell: bash
+      run: |
+        echo "version=${{ steps.prerelease.outputs.new-release-version }}" >> $GITHUB_OUTPUT
+        echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
+
+    - uses: open-turo/actions-node/build-docker@v5
+      if: steps.prerelease.outputs.new-release-published == 'true' && inputs.dockerhub-user != '' && inputs.dockerhub-password != ''
+      id: build-docker
+      with:
+        dockerhub-user: ${{ inputs.dockerhub-user }}
+        dockerhub-password: ${{ inputs.dockerhub-password }}
+        github-token: ${{ inputs.github-token }}
+        artifactory-username: ${{ inputs.artifactory-username }}
+        artifactory-auth-token: ${{ inputs.artifactory-auth-token }}
+        npm-auth-token: ${{ inputs.npm-auth-token }}
+        npm-token: ${{ inputs.npm-token }}
+        image-version: ${{ steps.vars.outputs.version }}
+        docker-metadata-tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}},value=${{ steps.vars.outputs.version }}
+
+    - name: Add new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      env:
+        NEW_VERSION: ${{ steps.vars.outputs.version }}
+        DOCKER_IMAGE: ${{ steps.build-docker.outputs.image-with-tag }}
+      run: |
+        echo "::notice::new version: \`${NEW_VERSION}\`"
+        echo "#### New version: \`${NEW_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "#### Docker image: \`${DOCKER_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+
+    - name: Add no new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published != 'true'
+      run: |
+        echo "::notice::no new version"
+        echo "### New version: 'NONE" >> $GITHUB_STEP_SUMMARY
+
+    - name: Check for release notes comment
+      uses: peter-evans/find-comment@v2
+      id: fc-prerelease
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      with:
+        issue-number: ${{ steps.PR.outputs.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: "<!-- prerelease comment -->"
+    - name: Delete previous release note
+      if: steps.fc-prerelease.outputs.comment-id != ''
+      uses: jungwinter/comment@v1
+      with:
+        type: delete
+        comment_id: ${{ steps.fc-prerelease.outputs.comment-id }}
+        token: ${{ inputs.github-token }}
+
+    - name: Upsert build version
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ steps.PR.outputs.number }}
+        body: |
+          <!-- prerelease comment -->
+          ## Prerelease build
+
+          **Build version:** `${{ steps.vars.outputs.version }}`
+          **Docker image:** `${{ steps.build-docker.outputs.image-with-tag }}`
+
+          [Build output](${{ steps.vars.outputs.run-url }})

--- a/release/README.md
+++ b/release/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Release
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that publishes a new release.
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Configuration
 

--- a/release/README.md
+++ b/release/README.md
@@ -36,6 +36,10 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 | --- | --- | --- | --- |
 | checkout-repo | Perform checkout as first step of action | `false` | true |
 | github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
+| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
+| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
+| dockerhub-user | username for dockerhub | `false` |  |
+| dockerhub-password | password for dockerhub | `false` |  |
 | npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
 | npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
 | dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -64,22 +64,10 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
-    - name: Build (yarn)
-      if: steps.check_yarn_lock.outputs.files_exists == 'true'
-      shell: bash
-      run: yarn build
-      env:
-        NODE_ENV: production
-        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-        NPM_TOKEN: ${{ inputs.npm-token }}
-    - name: Build (npm)
-      if: steps.check_yarn_lock.outputs.files_exists == 'false'
-      shell: bash
-      run: npm run build
-      env:
-        NODE_ENV: production
-        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-        NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Build
+      uses: open-turo/actions-node/build@v5
+      with:
+        checkout-repo: false
     - name: Release
       id: release
       uses: open-turo/actions-release/semantic-release@v4

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -9,6 +9,21 @@ inputs:
     required: true
     description: GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     default: ${{ github.token }}
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.
+    default: .docker-config.json
+  docker-flavor:
+    required: false
+    description: Docker flavor to use for docker metadata
+    default: |
+      latest=false
+  dockerhub-user:
+    required: false
+    description: username for dockerhub
+  dockerhub-password:
+    required: false
+    description: password for dockerhub
   npm-auth-token:
     required: false
     description: The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
@@ -79,3 +94,19 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+    - uses: open-turo/actions-node/build-docker@v5
+      id: docker-build
+      if: dockerhub-user != '' && dockerhub-password != ''
+      with:
+        docker-config-file: ${{ inputs.docker-config-file }}
+        dockerhub-user: ${{ inputs.dockerhub-user }}
+        dockerhub-password: ${{ inputs.dockerhub-password }}
+        github-token: ${{ inputs.github-token }}
+        npm-auth-token: ${{ inputs.npm-auth-token }}
+        npm-token: ${{ inputs.npm-token }}
+        image-version: ${{ steps.release.outputs.new-release-version }}
+        docker-flavor: ${{ inputs.docker-flavor }}
+        docker-metadata-tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Test
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that tests a node based repository
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 


### PR DESCRIPTION

**Description**

This PR adds 3 new actions:

* `build-docker` - Build a docker image for the project
* `build` - Run the `build` NPM script in a project - this was being done as part of release, but now we need it for prerelease too 
* `prerelease` - Trigger a release from a PR when the prerelease label is there (optionally building a docker image)

Now `release` also optionally builds docker images

This is inspired by `actions-jvm` and follows the same idea of having a local `.docker-config` file for the docker image name

**Changes**

* feat: add a build-docker action
* feat: add a build action
* refactor(release): use internal build action
* feat(release): build docker as part of release
* docs: update actions readme to rely on action docs even more
* feat: add prerelease action
* chore: use current branch for internal action refs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
