### PR TITLE
fix(release): use correct refs for dockerhub inputs

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -96,7 +96,7 @@ runs:
         NPM_TOKEN: ${{ inputs.npm-token }}
     - uses: open-turo/actions-node/build-docker@v5
       id: docker-build
-      if: dockerhub-user != '' && dockerhub-password != ''
+      if: inputs.dockerhub-user != '' && inputs.dockerhub-password != ''
       with:
         docker-config-file: ${{ inputs.docker-config-file }}
         dockerhub-user: ${{ inputs.dockerhub-user }}


### PR DESCRIPTION

**Description**

We are missing the `inputs.` prefix when checking if we should build a docker image

**Changes**

* fix(release): use correct refs for dockerhub inputs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
