### PR TITLE
fix(release): only support releases from default branches or PRs

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -89,10 +89,24 @@ runs:
         checkout-repo: false
         npm-auth-token: ${{ inputs.npm-auth-token }}
         npm-token: ${{ inputs.npm-token }}
+    - uses: 8BitJonny/gh-get-current-pr@2.2.0
+      id: PR
+      with:
+        sha: ${{ steps.source-vars.outputs.sha }}
+    - name: Branches configuration
+      id: branches-configuration
+      shell: bash
+      run: |
+        if [ -z "${{ steps.PR.outputs.number }}" ]; then
+          echo "branches=${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+        else
+          echo "branches=[\"${{ github.event.repository.default_branch }}\", {\"name\": \"${{ github.ref_name }}\",\"channel\": \"next\",\"prerelease\": \"pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}\"}]" >> $GITHUB_OUTPUT
+        fi
     - name: Release
       id: release
       uses: open-turo/actions-release/semantic-release@v4
       with:
+        branches: ${{ steps.branches-configuration.outputs.branches }}
         dry-run: ${{ inputs.dry-run }}
         extra-plugins: ${{ inputs.extra-plugins }}
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
**Description**

In repositories where we have many many branches semantic release takes a long time to run when using https://github.com/open-turo/semantic-release-config. This change updates the release action so it can only be triggered on the repository default branch or in PR branches.

This should speed things up in those repositories.

This also creates the side effect that we will only allow releases from PRs or the repository default branch, which works for our use cases (if needed we could always add inputs to use different branches or try to reconcile things with any releaserc file that is there locally, but all that is future work).

**Changes**

* fix(release): only support releases from default branches or PRs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)