### PR TITLE
fix: ensures docker build is not executed without a release number

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -116,7 +116,7 @@ runs:
         NPM_TOKEN: ${{ inputs.npm-token }}
     - uses: open-turo/actions-node/build-docker@v5
       id: docker-build
-      if: inputs.dockerhub-user != '' && inputs.dockerhub-password != ''
+      if: inputs.dockerhub-user != '' && inputs.dockerhub-password != '' && steps.release.outputs.new-release-version != ''
       with:
         docker-config-file: ${{ inputs.docker-config-file }}
         dockerhub-user: ${{ inputs.dockerhub-user }}


### PR DESCRIPTION

**Description**

Currently, running `release` when there are no commits to release, causes an error because docker-build is triggered unintentionally.



**Changes**

* fix: ensures docker build is not executed without a release number

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
