### PR TITLE
fix(lint): pass npm tokens to lint-release-notes

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -92,3 +92,6 @@ runs:
     - name: Check release notes on pull_request
       if: github.event_name == 'pull_request'
       uses: open-turo/actions-release/lint-release-notes@v4
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }


### PR DESCRIPTION

**Description**

NPM libs require the NPM token to be present when running semantic-release

**Changes**

* fix(lint): pass npm tokens to lint-release-notes

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
