### PR TITLE
fix(lint): use glob pattern to capture different pre-commit file extensions

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -68,7 +68,7 @@ runs:
       id: check_pre_commit_config
       uses: andstor/file-existence-action@v2
       with:
-        files: ".pre-commit-config.yaml, .pre-commit-config.yml"
+        files: .pre-commit-config.*
     - name: Pre-commit
       if: steps.check_pre_commit_config.outputs.files_exists == 'true'
       uses: open-turo/action-pre-commit@v1


### PR DESCRIPTION
**Description**

The OSS action we use for file existence was designed to check for "all" files rather than "any" file in a list, we hack our way around this for now by using a glob pattern which captures any file extension, since the file we are after has a pretty unique name

Fixes [#CP-1283](https://team-turo.atlassian.net//browse/CP-1283)

**Changes**

* fix: use glob pattern to capture different pre-commit file extensions

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
