### PR TITLE
ci: pin action-docs version and update readme for it to work

### DIFF
--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -2,10 +2,6 @@
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-description source="action.yaml"  -->
-## Description
-
-Builds and push docker images for the input platform, tags and image version
-<!-- action-docs-description -->
 <!-- prettier-ignore-end -->
 
 ## Usage
@@ -50,25 +46,23 @@ steps:
         type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
 ```
 
-<!-- prettier-ignore-start source="action.yaml"  -->
-<!-- action-docs-inputs -->
-
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter            | description                                                                                                                                                                                    | required | default             |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| docker-config-file   | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.                                                                               | `false`  | .docker-config.json |
-| docker-flavor        | Docker flavor to use for docker metadata                                                                                                                                                       | `false`  | latest=false        |
-| dockerhub-user       | username for dockerhub                                                                                                                                                                         | `true`   |                     |
-| dockerhub-password   | password for dockerhub                                                                                                                                                                         | `true`   |                     |
-| github-token         | Usually secrets.GITHUB_TOKEN                                                                                                                                                                   | `true`   |                     |
-| npm-auth-token       | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret | `false`  |                     |
-| npm-token            | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret                                  | `false`  |                     |
-| image-version        | Docker image version                                                                                                                                                                           | `true`   |                     |
-| image-platform       | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)                                                                                                               | `false`  | linux/amd64         |
-| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input                                                                                          | `false`  |                     |
-
-<!-- action-docs-inputs -->
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `docker-config-file` | <p>Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.</p> | `false` | `.docker-config.json` |
+| `docker-flavor` | <p>Docker flavor to use for docker metadata</p> | `false` | `latest=false ` |
+| `dockerhub-user` | <p>username for dockerhub</p> | `true` | `""` |
+| `dockerhub-password` | <p>password for dockerhub</p> | `true` | `""` |
+| `github-token` | <p>Usually secrets.GITHUB_TOKEN</p> | `true` | `""` |
+| `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret</p> | `false` | `""` |
+| `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret</p> | `false` | `""` |
+| `image-version` | <p>Docker image version</p> | `true` | `""` |
+| `image-platform` | <p>Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)</p> | `false` | `linux/amd64` |
+| `docker-metadata-tags` | <p>'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input</p> | `false` | `""` |
+<!-- action-docs-inputs source="action.yaml" -->
 <!-- action-docs-outputs source="action.yaml"  -->
 
 ## Outputs
@@ -78,14 +72,11 @@ steps:
 | image-name     | Docker image name                                  |
 | image-with-tag | Full image with tag - <image-name>:<image-version> |
 
-<!-- action-docs-outputs -->
 <!-- action-docs-runs source="action.yaml"  -->
 
 ## Runs
 
 This action is a `composite` action.
 
-<!-- action-docs-runs -->
 <!-- action-docs-usage source="action.yaml"   -->
-<!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -1,7 +1,7 @@
 # GitHub Action Build Docker
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml"  -->
 ## Description
 
 Builds and push docker images for the input platform, tags and image version
@@ -50,36 +50,42 @@ steps:
         type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
 ```
 
-<!-- prettier-ignore-start -->
+<!-- prettier-ignore-start source="action.yaml"  -->
 <!-- action-docs-inputs -->
+
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
-| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
-| dockerhub-user | username for dockerhub | `true` |  |
-| dockerhub-password | password for dockerhub | `true` |  |
-| github-token | Usually secrets.GITHUB_TOKEN | `true` |  |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret | `false` |  |
-| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret | `false` |  |
-| image-version | Docker image version | `true` |  |
-| image-platform | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc) | `false` | linux/amd64 |
-| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input | `false` |  |
+| parameter            | description                                                                                                                                                                                    | required | default             |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| docker-config-file   | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.                                                                               | `false`  | .docker-config.json |
+| docker-flavor        | Docker flavor to use for docker metadata                                                                                                                                                       | `false`  | latest=false        |
+| dockerhub-user       | username for dockerhub                                                                                                                                                                         | `true`   |                     |
+| dockerhub-password   | password for dockerhub                                                                                                                                                                         | `true`   |                     |
+| github-token         | Usually secrets.GITHUB_TOKEN                                                                                                                                                                   | `true`   |                     |
+| npm-auth-token       | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. Gets pass to the docker build as a secret | `false`  |                     |
+| npm-token            | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. Gets passed to the docker build as a secret                                  | `false`  |                     |
+| image-version        | Docker image version                                                                                                                                                                           | `true`   |                     |
+| image-platform       | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)                                                                                                               | `false`  | linux/amd64         |
+| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input                                                                                          | `false`  |                     |
+
 <!-- action-docs-inputs -->
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml"  -->
+
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| image-name | Docker image name |
+| parameter      | description                                        |
+| -------------- | -------------------------------------------------- |
+| image-name     | Docker image name                                  |
 | image-with-tag | Full image with tag - <image-name>:<image-version> |
+
 <!-- action-docs-outputs -->
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="action.yaml"  -->
+
 ## Runs
 
 This action is a `composite` action.
+
 <!-- action-docs-runs -->
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="action.yaml"   -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/build/README.md
+++ b/build/README.md
@@ -1,13 +1,12 @@
 # GitHub Action Build
 
-<!-- prettier-ignore-start source="action.yaml"  -->
+<!-- prettier-ignore-start   -->
 <!-- action-docs-description -->
 
 ## Description
 
 GitHub Action that builds Node based repository
 
-<!-- action-docs-description -->
 <!-- prettier-ignore-end -->
 
 ## Usage
@@ -48,15 +47,46 @@ This action runs the following lint checks:
 | github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
 | npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
 | npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
-<!-- action-docs-inputs -->
 <!-- action-docs-outputs source="action.yaml"  -->
-
-<!-- action-docs-outputs -->
 <!-- action-docs-runs source="action.yaml"  -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs -->
 <!-- action-docs-usage source="action.yaml" -->
-<!-- action-docs-usage -->
+## Usage
+
+```yaml
+- uses: @
+  with:
+    checkout-repo:
+    # Perform checkout as first step of action
+    #
+    # Required: false
+    # Default: true
+
+    build-script:
+    # Custom script to run, should be defined in package.json.
+    #
+    # Required: false
+    # Default: build
+
+    github-token:
+    # GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
+    #
+    # Required: true
+    # Default: ${{ github.token }}
+
+    npm-auth-token:
+    # The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.
+    #
+    # Required: false
+    # Default: ""
+
+    npm-token:
+    # The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+    #
+    # Required: false
+    # Default: ""
+```
+<!-- action-docs-usage source="action.yaml" -->
 <!-- prettier-ignore-end -->

--- a/build/README.md
+++ b/build/README.md
@@ -1,10 +1,12 @@
 # GitHub Action Build
 
-<!-- prettier-ignore-start -->
+<!-- prettier-ignore-start source="action.yaml"  -->
 <!-- action-docs-description -->
+
 ## Description
 
 GitHub Action that builds Node based repository
+
 <!-- action-docs-description -->
 <!-- prettier-ignore-end -->
 
@@ -36,7 +38,7 @@ This action runs the following lint checks:
 - This expects that `.commitlintrc.yaml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="action.yaml"  -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -47,14 +49,14 @@ This action runs the following lint checks:
 | npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
 | npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
 <!-- action-docs-inputs -->
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml"  -->
 
 <!-- action-docs-outputs -->
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="action.yaml"  -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="action.yaml" -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -29,7 +29,7 @@ runs:
       with:
         fetch-depth: 0
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Check for yarn.lock
       id: check_yarn_lock
       uses: andstor/file-existence-action@v3

--- a/lint/README.md
+++ b/lint/README.md
@@ -5,7 +5,7 @@
 ## Description
 
 GitHub Action that lints a Node based repository
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 <!-- prettier-ignore-end -->
 
 ## Usage
@@ -39,23 +39,22 @@ This action runs the following lint checks:
 <!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter | description | required | default |
+| name | description | required | default |
 | --- | --- | --- | --- |
-| checkout-repo | Perform checkout as first step of action | `false` | true |
-| lint-script | Custom script to run, should be defined in package.json. | `false` | lint |
-| github-token | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
-| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
-| internal-dependency-prefixes | Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values e.g. '@turo,@example'. | `false` |  |
-<!-- action-docs-inputs -->
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `lint-script` | <p>Custom script to run, should be defined in package.json.</p> | `false` | `lint` |
+| `github-token` | <p>GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `${{ github.token }}` |
+| `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
+| `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |
+| `internal-dependency-prefixes` | <p>Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values e.g. '@turo,@example'.</p> | `false` | `""` |
+<!-- action-docs-inputs source="action.yaml" -->
 <!-- action-docs-outputs source="action.yaml" -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml" -->
 <!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="action.yaml" -->
 <!-- action-docs-usage source="action.yaml"  -->
-<!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,7 +1,7 @@
 # GitHub Action Lint
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that lints a Node based repository
@@ -36,7 +36,7 @@ This action runs the following lint checks:
 - This expects that `.commitlintrc.yaml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -48,14 +48,14 @@ This action runs the following lint checks:
 | npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
 | internal-dependency-prefixes | Prefixes used to match internal dependencies and disallow beta versions. Can take comma-separated values e.g. '@turo,@example'. | `false` |  |
 <!-- action-docs-inputs -->
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml" -->
 
 <!-- action-docs-outputs -->
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="action.yaml"  -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -32,7 +32,7 @@ runs:
       with:
         fetch-depth: 0
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Check for yarn.lock
       id: check_yarn_lock
       uses: andstor/file-existence-action@v3

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -5,7 +5,7 @@
 ## Description
 
 < GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release. Meant to only be run in the context of a pull request. This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR and docker credentials are present
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 <!-- prettier-ignore-end -->
 
 ## Configuration
@@ -37,40 +37,35 @@ required permission to operate on protected branches.
 <!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter | description | required | default |
+| name | description | required | default |
 | --- | --- | --- | --- |
-| checkout-repo | Perform checkout as first step of action | `false` | true |
-| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags | `false` | 0 |
-| create-prerelease | Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating | `false` | false |
-| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
-| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
-| dockerhub-user | username for dockerhub | `false` |  |
-| dockerhub-password | password for dockerhub | `false` |  |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
-| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
-<!-- action-docs-inputs -->
-
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
+| `create-prerelease` | <p>Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating</p> | `false` | `false` |
+| `github-token` | <p>GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `${{ github.token }}` |
+| `docker-config-file` | <p>Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.</p> | `false` | `.docker-config.json` |
+| `dockerhub-user` | <p>username for dockerhub</p> | `false` | `""` |
+| `dockerhub-password` | <p>password for dockerhub</p> | `false` | `""` |
+| `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
+| `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |
+| `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
+<!-- action-docs-inputs source="action.yaml" -->
 <!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
-| parameter | description |
+| name | description |
 | --- | --- |
-| new-release-published | Whether a new release was published |
-| new-release-version | Version of the new release |
-| new-release-major-version | Major version of the new release |
-| image-name | Docker image name |
-| image-with-tag | Full image with tag - <image-name>:<image-version> |
-| pull-request-number | Pull request number |
-| run-url | URL to the GHA run |
-<!-- action-docs-outputs -->
-
+| `new-release-published` | <p>Whether a new release was published</p> |
+| `new-release-version` | <p>Version of the new release</p> |
+| `new-release-major-version` | <p>Major version of the new release</p> |
+| `image-name` | <p>Docker image name</p> |
+| `image-with-tag` | <p>Full image with tag - <image-name>:<image-version></p> |
+| `pull-request-number` | <p>Pull request number</p> |
+| `run-url` | <p>URL to the GHA run</p> |
+<!-- action-docs-outputs source="action.yaml" -->
 <!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs -->
-
-<!-- action-docs-usage source="action.yaml"  -->
-<!-- action-docs-usage -->
+<!-- action-docs-runs source="action.yaml" -->
 <!-- prettier-ignore-end -->

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -1,7 +1,7 @@
 # GitHub Action: Prerelease
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 < GitHub Action to compute a prerelease version based on the latest release version and the number of commits since the latest release. Meant to only be run in the context of a pull request. This will also generate a docker tag based on the computed version if the label `prerelease` is specified on the PR and docker credentials are present
@@ -34,7 +34,7 @@ of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. 
 required permission to operate on protected branches.
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -51,7 +51,7 @@ required permission to operate on protected branches.
 | extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -65,12 +65,12 @@ required permission to operate on protected branches.
 | run-url | URL to the GHA run |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="action.yaml"  -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -146,7 +146,7 @@ runs:
         echo "::debug::labels.contains('prerelease'): ${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}"
 
     # Compute next release
-    - uses: open-turo/action-setup-tools@v1
+    - uses: open-turo/action-setup-tools@v2
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
 
     - name: Build

--- a/release/README.md
+++ b/release/README.md
@@ -5,7 +5,7 @@
 ## Description
 
 GitHub Action that publishes a new release.
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 <!-- prettier-ignore-end -->
 
 ## Configuration
@@ -32,46 +32,39 @@ steps:
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v3` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
-<!-- prettier-ignore-start source="action.yaml" -->
-<!-- action-docs-inputs -->
-
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
-| parameter            | description                                                                                                                                                               | required | default                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------- |
-| checkout-repo        | Perform checkout as first step of action                                                                                                                                  | `false`  | true                               |
-| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags                                                                                         | `false`  | 0                                  |
-| github-token         | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   | ${{ github.token }}                |
-| docker-config-file   | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.                                                          | `false`  | .docker-config.json                |
-| docker-flavor        | Docker flavor to use for docker metadata                                                                                                                                  | `false`  | latest=false                       |
-| dockerhub-user       | username for dockerhub                                                                                                                                                    | `false`  |                                    |
-| dockerhub-password   | password for dockerhub                                                                                                                                                    | `false`  |                                    |
-| npm-auth-token       | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.                      | `false`  |                                    |
-| npm-token            | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                                         | `false`  |                                    |
-| dry-run              | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                                     | `false`  | false                              |
-| extra-plugins        | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config |
-
-<!-- action-docs-inputs -->
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
+| `github-token` | <p>GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `${{ github.token }}` |
+| `docker-config-file` | <p>Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.</p> | `false` | `.docker-config.json` |
+| `docker-flavor` | <p>Docker flavor to use for docker metadata</p> | `false` | `latest=false ` |
+| `dockerhub-user` | <p>username for dockerhub</p> | `false` | `""` |
+| `dockerhub-password` | <p>password for dockerhub</p> | `false` | `""` |
+| `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
+| `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |
+| `dry-run` | <p>Whether to run semantic release in <code>dry-run</code> mode. It will override the <code>dryRun</code> attribute in your configuration file</p> | `false` | `false` |
+| `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
+<!-- action-docs-inputs source="action.yaml" -->
 <!-- action-docs-outputs source="action.yaml" -->
-
 ## Outputs
 
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
-
-<!-- action-docs-outputs -->
-<!-- action-docs-runs -->
-
+| name | description |
+| --- | --- |
+| `new-release-published` | <p>Whether a new release was published</p> |
+| `new-release-version` | <p>Version of the new release</p> |
+| `new-release-major-version` | <p>Major version of the new release</p> |
+<!-- action-docs-outputs source="action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-
 <!-- action-docs-runs source="action.yaml" -->
 <!-- action-docs-usage source="action.yaml"  -->
-<!-- action-docs-usage -->
 <!-- prettier-ignore-end -->
 
 ## Additional Examples

--- a/release/README.md
+++ b/release/README.md
@@ -1,7 +1,7 @@
 # GitHub Action Release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that publishes a new release.
@@ -32,39 +32,45 @@ steps:
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
 If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v3` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
-<!-- prettier-ignore-start -->
+<!-- prettier-ignore-start source="action.yaml" -->
 <!-- action-docs-inputs -->
+
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| checkout-repo | Perform checkout as first step of action | `false` | true |
-| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags | `false` | 0 |
-| github-token | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` | ${{ github.token }} |
-| docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false` | .docker-config.json |
-| docker-flavor | Docker flavor to use for docker metadata | `false` | latest=false  |
-| dockerhub-user | username for dockerhub | `false` |  |
-| dockerhub-password | password for dockerhub | `false` |  |
-| npm-auth-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file. | `false` |  |
-| npm-token | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry. | `false` |  |
-| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` | false |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+| parameter            | description                                                                                                                                                               | required | default                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------- |
+| checkout-repo        | Perform checkout as first step of action                                                                                                                                  | `false`  | true                               |
+| checkout-fetch-depth | The number of commits to fetch. 0 indicates all history for all branches and tags                                                                                         | `false`  | 0                                  |
+| github-token         | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   | ${{ github.token }}                |
+| docker-config-file   | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.                                                          | `false`  | .docker-config.json                |
+| docker-flavor        | Docker flavor to use for docker metadata                                                                                                                                  | `false`  | latest=false                       |
+| dockerhub-user       | username for dockerhub                                                                                                                                                    | `false`  |                                    |
+| dockerhub-password   | password for dockerhub                                                                                                                                                    | `false`  |                                    |
+| npm-auth-token       | The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.                      | `false`  |                                    |
+| npm-token            | The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.                                                         | `false`  |                                    |
+| dry-run              | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                                     | `false`  | false                              |
+| extra-plugins        | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config |
+
 <!-- action-docs-inputs -->
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="action.yaml" -->
+
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| new-release-published | Whether a new release was published |
-| new-release-version | Version of the new release |
-| new-release-major-version | Major version of the new release |
+| parameter                 | description                         |
+| ------------------------- | ----------------------------------- |
+| new-release-published     | Whether a new release was published |
+| new-release-version       | Version of the new release          |
+| new-release-major-version | Major version of the new release    |
+
 <!-- action-docs-outputs -->
 <!-- action-docs-runs -->
+
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs -->
-<!-- action-docs-usage  -->
+
+<!-- action-docs-runs source="action.yaml" -->
+<!-- action-docs-usage source="action.yaml"  -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -63,7 +63,7 @@ runs:
         fetch-depth: ${{ inputs.checkout-fetch-depth }}
         persist-credentials: false
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Check for yarn.lock
       id: check_yarn_lock
       uses: andstor/file-existence-action@v3

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -8,7 +8,9 @@ for i in $*; do
     echo "skipping: ${i}"
     continue
   fi
-  readme_file=$(dirname "$i")/README.md
-  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
-  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+
+  echo "npx action-docs --no-banner -s "${i}""
+  cd $(dirname "$i")
+  npx action-docs@2 --no-banner -s action.yaml -u README.md || echo "action-docs failed for $i"
+  cd -
 done

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -26,7 +26,7 @@ runs:
       uses: actions/checkout@v3
       if: inputs.checkout-repo == 'true'
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Check for yarn.lock
       id: check_yarn_lock
       uses: andstor/file-existence-action@v2


### PR DESCRIPTION

**Description**

action-docs were failing and this PR also updates action-setup-tools (couldn't figure out why renovate wasn't picking this update)

**Changes**

* ci: pin action-docs version and update readme for it to work
* docs: generate docs
* build(deps): use actions-setup-tools@v2

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
