### PR TITLE
CP: Add back persist-credentials to checkout step in install-dependencies

### DIFF
--- a/install-dependencies/action.yaml
+++ b/install-dependencies/action.yaml
@@ -36,6 +36,7 @@ runs:
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup tools
       uses: open-turo/action-setup-tools@v2
     - name: Check for yarn.lock


### PR DESCRIPTION
## Summary
In https://github.com/open-turo/actions-node/pull/66 a bug was introduce where we forgot to pass `persist-credentials: false` to the Checkout step. 

## Changes
* fix: add back persist-credentials