### PR TITLE
fix: update actions-release to v5

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -84,7 +84,7 @@ runs:
       shell: bash
     - name: Check release notes on pull_request
       if: github.event_name == 'pull_request'
-      uses: open-turo/actions-release/lint-release-notes@v4
+      uses: open-turo/actions-release/lint-release-notes@v5
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -159,7 +159,7 @@ runs:
 
     - name: Prerelease
       id: prerelease
-      uses: open-turo/actions-release/semantic-release@v4
+      uses: open-turo/actions-release/semantic-release@v5
       if: steps.check-pr.outputs.has_prerelease_label == 'true'
       with:
         branches: '["${{ github.event.repository.default_branch }}", {"name": "${{ steps.source-vars.outputs.branch }}","channel": "next","prerelease": "pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}"}]'

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -91,7 +91,7 @@ runs:
         fi
     - name: Release
       id: release
-      uses: open-turo/actions-release/semantic-release@v4
+      uses: open-turo/actions-release/semantic-release@v5
       with:
         branches: ${{ steps.branches-configuration.outputs.branches }}
         dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
**Description**

Update `actions-release` to the latest version. It requires semantic-release 23 (noop on this repo).

I don't think this should be a breaking change in this action, but we could go that way to be extra cautious. Maybe the tests in the TODOs are enough for this.

Not sure why renovatebot is not picking these updates.

Everything is working fine 🎉 

**TODOs**

- [x] Test this update in a open-turo lib - https://github.com/open-turo/eslint-config-typescript/pull/306
- [x] Test this in an internal turo lib - see PR link in references in history below


**Changes**

* fix: update actions-release to v5

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
