### PR TITLE
feat: upgrade everpcpc/actions-cache to v2

### DIFF
--- a/install-dependencies/action.yaml
+++ b/install-dependencies/action.yaml
@@ -51,7 +51,7 @@ runs:
       shell: bash
     - name: Load cached node_modules if available
       if: inputs.s3-bucket-name != ''
-      uses: everpcpc/actions-cache@v1
+      uses: everpcpc/actions-cache@v2
       id: read_cache
       with:
         bucket: ${{ inputs.s3-bucket-name }}
@@ -76,7 +76,7 @@ runs:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Cache node_modules
       if: inputs.s3-bucket-name != '' &&  steps.read_cache.outputs.cache-hit != 'true'
-      uses: everpcpc/actions-cache@v1
+      uses: everpcpc/actions-cache@v2
       id: write_cache
       with:
         bucket: ${{ inputs.s3-bucket-name }}


### PR DESCRIPTION
to use node20

https://github.com/everpcpc/actions-cache/releases/tag/v2

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/