### PR TITLE
feat: cache pre-commit in s3

### DIFF
--- a/install-dependencies/action.yaml
+++ b/install-dependencies/action.yaml
@@ -73,16 +73,3 @@ runs:
       run: npm ci
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
-    - name: Cache node_modules
-      if: inputs.s3-bucket-name != '' &&  steps.read_cache.outputs.cache-hit != 'true'
-      uses: everpcpc/actions-cache@v2
-      id: write_cache
-      with:
-        bucket: ${{ inputs.s3-bucket-name }}
-        use-fallback: false
-        path: node_modules
-        key: ${{ env.cache-name }}-${{ steps.lockfile_hash.outputs.hash }}
-        restore-keys: ${{ env.cache-name }}-
-      env:
-        AWS_REGION: ${{ inputs.s3-bucket-region }}
-        cache-name: ${{ github.event.repository.name }}/cache-node-modules

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -65,6 +65,9 @@ runs:
     - name: Pre-commit
       if: steps.check_pre_commit_config.outputs.files_exists == 'true'
       uses: open-turo/action-pre-commit@v3
+      with:
+        s3-bucket-name: ${{ inputs.s3-bucket-name }}
+        s3-bucket-region: ${{ inputs.s3-bucket-region }}
     - if: ${{ inputs.internal-dependency-prefixes != '' }}
       name: Create Beta Release Check Script
       run: |


### PR DESCRIPTION

**Description**

This PR updates this repo to be able to cache pre-commit hooks in S3. It depends on https://github.com/open-turo/action-pre-commit/pull/101

Apart from that removes an extra call to actions-cache, which is not needed since the action already has a post run logic to write the cache back to S3.

**Changes**

* feat: cache pre-commit in s3
* fix(install-dependencies): remove extra cache run

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
