### PR TITLE
fix(prerelease): use correct value for github-token

### DIFF
--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -232,4 +232,4 @@ runs:
 
           [Build output](${{ steps.vars.outputs.run-url }})
         comment-author: "github-actions[bot]"
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}


### PR DESCRIPTION

**Description**

When updating the comment action, I used the wrong value for github-token.



**Changes**

* fix(prerelease): use correct value for github-token

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
