### PR TITLE
fix: avoid double-wrapping text-detector in a comment

### DIFF
--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -221,7 +221,7 @@ runs:
       if: steps.prerelease.outputs.new-release-published == 'true'
       with:
         workflow: ADD
-        text-detector: "<!-- prerelease comment -->"
+        text-detector: "prerelease comment"
         edit-mode: replace
         comment: |
           <!-- prerelease comment -->


### PR DESCRIPTION

**Description**

We are double-wrapping the text-detector in comment format. This fixes it by removing the comment wrappers from the text-detector.


**Changes**

* fix: avoid double-wrapping text-detector in a comment

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
