### PR TITLE
fix(test): use actions-node@v7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0 # Use the ref you want to point at
     hooks:

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Install dependencies
       id: install_dependencies
-      uses: open-turo/actions-node/install-dependencies@v6
+      uses: open-turo/actions-node/install-dependencies@v7
       with:
         checkout-repo: ${{ inputs.checkout-repo }}
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION

**Description**

For some reason renovatebot is not picking this one. Updating it manually

**Changes**

* fix(test): use actions-node@v7
* ci: update pre-commit config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
