### PR TITLE
feat(lint): skip eslint from pre-commit by default

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -60,6 +60,7 @@ This action runs the following lint checks:
 | --- | --- | --- | --- |
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
 | `lint-script` | <p>Custom script to run, should be defined in package.json.</p> | `false` | `lint` |
+| `pre-commit-skip-hooks` | <p>Comma separate list of pre-commit hooks to skip. e.g. 'eslint,prettier'</p> | `false` | `eslint` |
 | `github-token` | <p>GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `${{ github.token }}` |
 | `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
 | `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -9,6 +9,10 @@ inputs:
     required: false
     description: Custom script to run, should be defined in package.json.
     default: "lint"
+  pre-commit-skip-hooks:
+    required: false
+    description: Comma separate list of pre-commit hooks to skip. e.g. 'eslint,prettier'
+    default: "eslint"
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
@@ -65,6 +69,8 @@ runs:
     - name: Pre-commit
       if: steps.check_pre_commit_config.outputs.files_exists == 'true'
       uses: open-turo/action-pre-commit@v3
+      env:
+        SKIP: ${{ inputs.pre-commit-skip-hooks }}
       with:
         s3-bucket-name: ${{ inputs.s3-bucket-name }}
         s3-bucket-region: ${{ inputs.s3-bucket-region }}


### PR DESCRIPTION
**Description**

This action runs both a lint script and `pre-commit`. In our repos we tend to define `eslint` as a pre-commit hook.

This results in a redundant run of eslint in CI, making CI take double the time.

I think it makes sense to keep eslint as part of pre-commit in local environments, as that way we get a signal of errors we might be committing, but in CI disabling by default at least in this repo makes sense to speed things up.

An alternative would be to not run `eslint` as part of the `lint` script in those repos and just leverage the `pre-commit` run as well, which is what I think we are doing in some repos already.



**Changes**

* feat(lint): skip eslint from pre-commit by default

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
