### PR TITLE
DEVX-100: Enable to build arm64 kubesealer image

### DIFF
--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -49,6 +49,7 @@ required permission to operate on protected branches.
 | `dockerhub-password` | <p>password for dockerhub</p> | `false` | `""` |
 | `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
 | `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |
+| `image-platform` | <p>Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)</p> | `false` | `linux/amd64` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
 <!-- action-docs-inputs source="action.yaml" -->
 <!-- action-docs-outputs source="action.yaml" -->

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -41,6 +41,10 @@ inputs:
   npm-token:
     required: false
     description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+  image-platform:
+    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    required: false
+    default: linux/amd64
   extra-plugins:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
@@ -193,6 +197,7 @@ runs:
         npm-auth-token: ${{ inputs.npm-auth-token }}
         npm-token: ${{ inputs.npm-token }}
         image-version: ${{ steps.vars.outputs.version }}
+        image-platform: "${{ inputs.image-platform }}"
         docker-metadata-tags: |
           type=ref,event=branch
           type=ref,event=pr

--- a/release/README.md
+++ b/release/README.md
@@ -65,6 +65,7 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 | `dockerhub-password` | <p>password for dockerhub</p> | `false` | `""` |
 | `npm-auth-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against a private NPM registry configured via a .npmrc file.</p> | `false` | `""` |
 | `npm-token` | <p>The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.</p> | `false` | `""` |
+| `image-platform` | <p>Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)</p> | `false` | `linux/amd64` |
 | `dry-run` | <p>Whether to run semantic release in <code>dry-run</code> mode. It will override the <code>dryRun</code> attribute in your configuration file</p> | `false` | `false` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
 | `s3-bucket-name` | <p>S3 bucket name to cache node_modules to speed up dependency installation.</p> | `false` | `""` |

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -38,6 +38,10 @@ inputs:
   npm-token:
     required: false
     description: The Node Package Manager (npm) authentication token. This token is used to authenticate against the NPM registry.
+  image-platform:
+    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    required: false
+    default: linux/amd64
   dry-run:
     required: false
     description: Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
@@ -117,6 +121,7 @@ runs:
         npm-auth-token: ${{ inputs.npm-auth-token }}
         npm-token: ${{ inputs.npm-token }}
         image-version: ${{ steps.release.outputs.new-release-version }}
+        image-platform: "${{ inputs.image-platform }}"
         docker-flavor: ${{ inputs.docker-flavor }}
         docker-metadata-tags: |
           type=ref,event=branch


### PR DESCRIPTION
**Description**
 Enable to build arm64 kubesealer image.

Q: Do we want to set the default platform to both arm64 and x64? 
A: No, as it's slow to build both with emulation



**Changes**

* feat(gha): allow to input image-platform e.g arm64

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
