### PR TITLE
feat: add bun and pnpm support, refine npm logic to not be yarn-dependent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `open-turo/actions-node`
 
-GitHub Actions for `node` based repositories. It uses `yarn` as package manager.
+GitHub Actions for `node` based repositories. It supports `bun`, `pnpm`, `yarn`, and `npm` as package managers.
 
 [![Release](https://img.shields.io/github/v/release/open-turo/actions-node)](https://github.com/open-turo/actions-node/releases/)
 [![Tests pass/fail](https://img.shields.io/github/workflow/status/open-turo/actions-node/CI)](https://github.com/open-turo/actions-node/actions/)
@@ -15,7 +15,7 @@ GitHub Actions for `node` based repositories. It uses `yarn` as package manager.
 
 ### action: [`lint`](./lint)
 
-Lint will run pre-commit linters and eslint against the consumer repository, optionally checking out, and installing node, yarn and any other required tools with [action-setup-tools](https://github.com/open-turo/action-setup-tools).
+Lint will run pre-commit linters and eslint against the consumer repository, optionally checking out, and installing node, bun/pnpm/yarn/npm and any other required tools with [action-setup-tools](https://github.com/open-turo/action-setup-tools).
 
 See usage [here](./lint/README.md#usage).
 

--- a/build/action.yaml
+++ b/build/action.yaml
@@ -52,3 +52,17 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run build script (pnpm)
+      if: steps.install_dependencies.outputs.package-manager == 'pnpm'
+      shell: bash
+      run: pnpm ${{ inputs.build-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run build script (bun)
+      if: steps.install_dependencies.outputs.package-manager == 'bun'
+      shell: bash
+      run: bun run ${{ inputs.build-script }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}

--- a/docs/breaking-changes/v8.md
+++ b/docs/breaking-changes/v8.md
@@ -1,4 +1,0 @@
-# Breaking Changes in v8
-
-- Adds support for `bun` and `pnpm`
-  - Updates logic for existing `npm` and `yarn` detection, and so may inadvertently change behavior. Cutting as new major as a precaution.

--- a/docs/breaking-changes/v8.md
+++ b/docs/breaking-changes/v8.md
@@ -1,0 +1,4 @@
+# Breaking Changes in v8
+
+- Adds support for `bun` and `pnpm`
+  - Updates logic for existing `npm` and `yarn` detection, and so may inadvertently change behavior. Cutting as new major as a precaution.

--- a/install-dependencies/README.md
+++ b/install-dependencies/README.md
@@ -42,8 +42,7 @@ jobs:
 ## Notes
 
 - By default, this action will perform actions/checkout as its first step.
-- This action checks for a `yarn.lock` file to figure out which package manager
-  to use to install dependencies; it supports `npm` and `yarn`.
+- This action checks for `bun.lock`, `pnpm-lock.yaml`, `yarn.lock`, and `package-lock.json` to determine which package manager to use to install dependencies; it supports `bun`, `pnpm`, `yarn`, and `npm` (with priority given to bun, then pnpm, then yarn, then npm).
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-inputs source="action.yaml" -->

--- a/install-dependencies/README.md
+++ b/install-dependencies/README.md
@@ -63,7 +63,7 @@ jobs:
 | name | description |
 | --- | --- |
 | `cache-hit` | <p>Whether the cache was hit when installing dependencies</p> |
-| `package-manager` | <p>The package manager used to install dependencies</p> |
+| `package-manager` | <p>The package manager used to install dependencies. Falls back to NPM by default.</p> |
 <!-- action-docs-outputs source="action.yaml" -->
 <!-- action-docs-runs source="action.yaml" -->
 ## Runs

--- a/install-dependencies/action.yaml
+++ b/install-dependencies/action.yaml
@@ -26,8 +26,8 @@ outputs:
     description: Whether the cache was hit when installing dependencies
     value: ${{ steps.read_cache.outputs.cache-hit }}
   package-manager:
-    description: The package manager used to install dependencies
-    value: ${{ steps.check_bun_lock.outputs.files_exists == 'true' && 'bun' || (steps.check_pnpm_lock.outputs.files_exists == 'true' && 'pnpm' || (steps.check_yarn_lock.outputs.files_exists == 'true' && 'yarn') || (steps.check_npm_lock.outputs.files_exists == 'true' && 'npm')) }}
+    description: The package manager used to install dependencies. Falls back to NPM by default.
+    value: ${{ steps.check_bun_lock.outputs.files_exists == 'true' && 'bun' || (steps.check_pnpm_lock.outputs.files_exists == 'true' && 'pnpm' || (steps.check_yarn_lock.outputs.files_exists == 'true' && 'yarn') || 'npm') }}
 runs:
   using: composite
   steps:
@@ -61,7 +61,7 @@ runs:
     - name: Compute lockfile hash
       if: inputs.s3-bucket-name != ''
       id: lockfile_hash
-      run: echo "hash=${{ steps.check_bun_lock.outputs.files_exists == 'true' && hashFiles('**/bun.lock') || (steps.check_pnpm_lock.outputs.files_exists == 'true' && hashFiles('**/pnpm-lock.yaml') || (steps.check_yarn_lock.outputs.files_exists == 'true' && hashFiles('**/yarn.lock') || (steps.check_npm_lock.outputs.files_exists == 'true' && hashFiles('**/package-lock.json')))) }}" >> $GITHUB_OUTPUT
+      run: echo "hash=${{ steps.check_bun_lock.outputs.files_exists == 'true' && hashFiles('**/bun.lock') || (steps.check_pnpm_lock.outputs.files_exists == 'true' && hashFiles('**/pnpm-lock.yaml') || (steps.check_yarn_lock.outputs.files_exists == 'true' && hashFiles('**/yarn.lock') || hashFiles('**/package-lock.json'))) }}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Load cached node_modules if available
       if: inputs.s3-bucket-name != ''

--- a/install-dependencies/action.yaml
+++ b/install-dependencies/action.yaml
@@ -27,7 +27,7 @@ outputs:
     value: ${{ steps.read_cache.outputs.cache-hit }}
   package-manager:
     description: The package manager used to install dependencies
-    value: ${{ steps.check_yarn_lock.outputs.files_exists == 'true' && 'yarn' || 'npm' }}
+    value: ${{ steps.check_bun_lock.outputs.files_exists == 'true' && 'bun' || (steps.check_pnpm_lock.outputs.files_exists == 'true' && 'pnpm' || (steps.check_yarn_lock.outputs.files_exists == 'true' && 'yarn') || (steps.check_npm_lock.outputs.files_exists == 'true' && 'npm')) }}
 runs:
   using: composite
   steps:
@@ -38,15 +38,30 @@ runs:
         fetch-depth: 0
     - name: Setup tools
       uses: open-turo/action-setup-tools@v3
+    - name: Check for package-lock.json
+      id: check_npm_lock
+      uses: andstor/file-existence-action@v3
+      with:
+        files: package-lock.json
+    - name: Check for pnpm-lock.yaml
+      id: check_pnpm_lock
+      uses: andstor/file-existence-action@v3
+      with:
+        files: pnpm-lock.yaml
     - name: Check for yarn.lock
       id: check_yarn_lock
       uses: andstor/file-existence-action@v3
       with:
         files: yarn.lock
+    - name: Check for bun.lock
+      id: check_bun_lock
+      uses: andstor/file-existence-action@v3
+      with:
+        files: bun.lock
     - name: Compute lockfile hash
       if: inputs.s3-bucket-name != ''
       id: lockfile_hash
-      run: echo "hash=${{ steps.check_yarn_lock.outputs.files_exists == 'true' && hashFiles('**/yarn.lock') || hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
+      run: echo "hash=${{ steps.check_bun_lock.outputs.files_exists == 'true' && hashFiles('**/bun.lock') || (steps.check_pnpm_lock.outputs.files_exists == 'true' && hashFiles('**/pnpm-lock.yaml') || (steps.check_yarn_lock.outputs.files_exists == 'true' && hashFiles('**/yarn.lock') || (steps.check_npm_lock.outputs.files_exists == 'true' && hashFiles('**/package-lock.json')))) }}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Load cached node_modules if available
       if: inputs.s3-bucket-name != ''
@@ -61,6 +76,18 @@ runs:
       env:
         AWS_REGION: ${{ inputs.s3-bucket-region }}
         cache-name: ${{ github.event.repository.name }}/cache-node-modules
+    - name: Install dependencies (bun)
+      if: steps.check_bun_lock.outputs.files_exists == 'true'
+      shell: bash
+      run: bun install --frozen-lockfile
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+    - name: Install dependencies (pnpm)
+      if: steps.check_pnpm_lock.outputs.files_exists == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Install dependencies (yarn)
       if: steps.check_yarn_lock.outputs.files_exists == 'true'
       shell: bash
@@ -68,7 +95,7 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
     - name: Install dependencies (npm)
-      if: steps.check_yarn_lock.outputs.files_exists == 'false'
+      if: steps.check_npm_lock.outputs.files_exists == 'true'
       shell: bash
       run: npm ci
       env:

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -59,6 +59,22 @@ runs:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
       run: yarn $LINT_SCRIPT
+    - name: Run lint script (pnpm)
+      if: steps.install_dependencies.outputs.package-manager == 'pnpm'
+      shell: bash
+      env:
+        LINT_SCRIPT: ${{ inputs.lint-script }}
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: pnpm $LINT_SCRIPT
+    - name: Run lint script (bun)
+      if: steps.install_dependencies.outputs.package-manager == 'bun'
+      shell: bash
+      env:
+        LINT_SCRIPT: ${{ inputs.lint-script }}
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: bun run $LINT_SCRIPT
     - name: Check for .pre-commit-config file
       id: check_pre_commit_config
       uses: andstor/file-existence-action@v3

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -53,3 +53,17 @@ runs:
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run tests (pnpm)
+      if: steps.install_dependencies.outputs.package-manager == 'pnpm'
+      shell: bash
+      run: pnpm test ${{ inputs.test-flags }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
+    - name: Run tests (bun)
+      if: steps.install_dependencies.outputs.package-manager == 'bun'
+      shell: bash
+      run: bun test ${{ inputs.test-flags }}
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NPM_TOKEN: ${{ inputs.npm-token }}


### PR DESCRIPTION
The `actions-node` GHA is relatively brittle, expecting `yarn` as the package manager for repos that rely on it, though there is fallback logic to `npm` if no `yarn` artifacts are detected. This PR seeks to make the GHA compatible with two other tools: `bun` and `pnpm`. (`deno` was excluded to try not to add too much at once.) This will allow repos that rely on this GHA to use whichever tool best suits the needs for that given repo, without the restriction on `yarn` (classic) and `npm`.